### PR TITLE
config.toml: force "light" theme

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,7 @@ enableGitInfo = true
 [params]
   # (Optional, default light) Sets color theme: light, dark or auto.
   # Theme 'auto' switches between dark and light modes based on browser/os preferences
-  BookTheme = 'auto'
+  BookTheme = 'light'
 
   # (Optional, default true) Controls table of contents visibility on right side of pages.
   # Start and end levels can be controlled with markup.tableOfContents setting.


### PR DESCRIPTION
Our custom modifications do not support "dark"; we need to force "light" theme instead of using "auto".